### PR TITLE
Remove tagger and parser from pipeline

### DIFF
--- a/newlang_project/configs/config.cfg
+++ b/newlang_project/configs/config.cfg
@@ -10,7 +10,7 @@ seed = 0
 
 [nlp]
 lang = "kanbun"
-pipeline = ["tok2vec","tagger","parser","ner"]
+pipeline = ["tok2vec", "ner"]
 batch_size = 1000
 disabled = []
 before_creation = null
@@ -37,43 +37,6 @@ use_upper = true
 nO = null
 
 [components.ner.model.tok2vec]
-@architectures = "spacy.Tok2VecListener.v1"
-width = ${components.tok2vec.model.encode.width}
-upstream = "*"
-
-[components.parser]
-factory = "parser"
-learn_tokens = false
-min_action_freq = 30
-moves = null
-scorer = {"@scorers":"spacy.parser_scorer.v1"}
-update_with_oracle_cut_size = 100
-
-[components.parser.model]
-@architectures = "spacy.TransitionBasedParser.v2"
-state_type = "parser"
-extra_state_tokens = false
-hidden_width = 128
-maxout_pieces = 3
-use_upper = true
-nO = null
-
-[components.parser.model.tok2vec]
-@architectures = "spacy.Tok2VecListener.v1"
-width = ${components.tok2vec.model.encode.width}
-upstream = "*"
-
-[components.tagger]
-factory = "tagger"
-neg_prefix = "!"
-overwrite = false
-scorer = {"@scorers":"spacy.tagger_scorer.v1"}
-
-[components.tagger.model]
-@architectures = "spacy.Tagger.v1"
-nO = null
-
-[components.tagger.model.tok2vec]
 @architectures = "spacy.Tok2VecListener.v1"
 width = ${components.tok2vec.model.encode.width}
 upstream = "*"


### PR DESCRIPTION
This just removes the part-of-speech tagger and dependency parser, since we don't care about using them for now (just NER).